### PR TITLE
Added bower.json to help with grunt-wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "openlayers3",
+  "main": [
+    "build/ol.js",
+    "build/ol.css"
+  ]
+}


### PR DESCRIPTION
I'm new to the whole Bower, Grunt etc. toolchain but without a bower.json file and main section in particular the wiredep step doesn't add the necessary file references to the target.
